### PR TITLE
ArrayList.sort getting passed java.util.Comparator instead of Closure

### DIFF
--- a/src/groovy/net/hedtech/restfulapi/MediaTypeParser.groovy
+++ b/src/groovy/net/hedtech/restfulapi/MediaTypeParser.groovy
@@ -88,22 +88,20 @@ class MediaTypeParser {
                 }
             }
         }
-        return mimes.sort(new QualityComparator()) as MediaType[]
+
+        def comp = { t, t1 ->
+            def left = t.parameters.q.toBigDecimal()
+            def right = t1.parameters.q.toBigDecimal()
+            if (left > right) return -1
+            if (left < right) return 1
+            return 0
+        }
+
+        return mimes.sort(comp) as MediaType[]
     }
 
     private createMediaTypeAndAddToList(name, mimes, params = null) {
         def mime = params ? new MediaType(name, params) : new MediaType(name)
         mimes << mime
-    }
-}
-
-class QualityComparator implements Comparator {
-
-    int compare(Object t, Object t1) {
-        def left = t.parameters.q.toBigDecimal()
-        def right = t1.parameters.q.toBigDecimal()
-        if (left > right) return -1
-        if (left < right) return 1
-        return 0
     }
 }


### PR DESCRIPTION
I recently just upgraded my grails app to 2.4.0 and I'm actively using and loving this plugin so when it failed to return any http requests that should be handled by the restful-api plugin I went digging. The issue is very simple, the latest version of grails includes a newer version of groovy and the arraylist.sort method expects a boolean argument along with a java.util.Comparator when sorting that way. I quickly searched the rest of the code base and saw no other usage of Comparators so I modified MediaTypeParser to use a closure with the same functionality as the comparator.
