### PR TITLE
Fix for 415 Unsupported media type with delete

### DIFF
--- a/grails-app/controllers/net/hedtech/restfulapi/RestfulApiController.groovy
+++ b/grails-app/controllers/net/hedtech/restfulapi/RestfulApiController.groovy
@@ -635,8 +635,7 @@ class RestfulApiController {
         shaFor( resourceModel, digest, requestedMediaType )
     }
 
-
-    protected String shaFor( resourceModel, MessageDigest digest, String requestedMediaType ) {
+    protected boolean shaForUpdate( resourceModel, MessageDigest digest, String requestedMediaType ) {
 
         digest.update( requestedMediaType.getBytes( 'UTF-8' ) )
 
@@ -667,7 +666,12 @@ class RestfulApiController {
             digest.update( "${resourceModel.lastModified}".getBytes( 'UTF-8' ) )
         }
 
-        if (changeIndictorFound) {
+        return changeIndictorFound
+    }
+
+
+    protected String shaFor( resourceModel, MessageDigest digest, String requestedMediaType ) {
+        if (shaForUpdate(resourceModel, digest, requestedMediaType)) {
             log.trace "Returning an ETag based on id and a known change indicator"
             return "\"${new BigInteger( 1, digest.digest() ).toString( 16 ).padLeft( 40,'0' )}\""
         } else {
@@ -689,8 +693,9 @@ class RestfulApiController {
         digest.update( "${resourceModels.size()}".getBytes( 'UTF-8' ) )
         digest.update( "${totalCount}".getBytes( 'UTF-8' ) )
         resourceModels.each {
-            shaFor( it, digest, requestedMediaType )
+            shaForUpdate( it, digest, requestedMediaType )
         }
+
         "\"${new BigInteger( 1, digest.digest() ).toString( 16 ).padLeft( 40,'0' )}\""
     }
 


### PR DESCRIPTION
This issue is occurring when no content length is set in delete request (in a simple backbone.js application).
Statement request.getContentLength() evaluates to -1 for the request, in which case an attempt is done to parse the request content that doesn't exist, and it fails.
