### PR TITLE
Add support for returning custom response headers from a list service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ plugin.xml
 *en_PS.properties
 test/test-restful-api/web-app/css/**-rtl.css
 /plugin.xml
+/.settings
+/target-eclipse
+/.classpath
+/.project

--- a/grails-app/controllers/net/hedtech/restfulapi/RestfulApiController.groovy
+++ b/grails-app/controllers/net/hedtech/restfulapi/RestfulApiController.groovy
@@ -238,6 +238,11 @@ class RestfulApiController {
                     holder.addHeader(totalCountHeader, count)
                     holder.addHeader(pageOffsetHeader, requestParams.offset ? requestParams?.offset : 0)
                     holder.addHeader(pageMaxHeader, requestParams.max ? requestParams?.max : result.size())
+                    if (result.hasProperty("httpResponseHeaders") && result.httpResponseHeaders instanceof Map) {
+                        result.httpResponseHeaders.each {
+                            if (it.value != null) holder.addHeader(it.key, it.value.toString())
+                        }
+                    }
                     renderSuccessResponse( holder, 'default.rest.list.message' )
                 }
             }

--- a/src/groovy/net/hedtech/restfulapi/PagedResultArrayList.groovy
+++ b/src/groovy/net/hedtech/restfulapi/PagedResultArrayList.groovy
@@ -22,13 +22,19 @@ package net.hedtech.restfulapi
 class PagedResultArrayList extends ArrayList implements PagedResultList {
 
     private long totalCount
+    private Map httpResponseHeaders
 
-    PagedResultArrayList(Collection c, long totalCount) {
+    PagedResultArrayList(Collection c, long totalCount, Map httpResponseHeaders = null) {
         super(c)
         this.totalCount = totalCount
+        this.httpResponseHeaders = httpResponseHeaders
     }
 
     long getTotalCount() {
         totalCount
+    }
+
+    Map getHttpResponseHeaders() {
+        httpResponseHeaders
     }
 }


### PR DESCRIPTION
We want to return some metadata about the response of a list service request in the response headers, much in the same way that totalCount and other paging parameters are returned.  We've modified the RestfulApiController to check if an httpResponseHeaders property exists on the object returned by the list. If that property exists and is a map, we generate the response headers directly from that map.  For simplicity, we incorporated an optional responseHeaders as part of the PagedResultArrayList object in which to pass the map to the controller. This branch is based off the 0.8.0 tag as that is the version of the restful-api currently in use by our project.